### PR TITLE
ci: add stale bot reusable workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+# name: Close stale issues
+#
+# on:
+#   schedule:
+#     - cron: "30 12 * * *"
+#
+# jobs:
+#   stale:
+#     permissions:
+#       issues: write
+#       pull-requests: write
+#
+#     uses: hetznercloud/.github/.github/workflows/stale.yml@main
+
+name: Close stale issues
+
+on:
+  workflow_call:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: >-
+            This issue has been marked as stale because it has not had recent activity.
+            The bot will close the issue if no further action occurs.
+          stale-pr-message: >-
+            This PR has been marked as stale because it has not had recent activity.
+            The bot will close the PR if no further action occurs.
+          exempt-issue-labels: pinned
+          exempt-pr-labels: pinned
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-close: 30
+          days-before-stale: 90


### PR DESCRIPTION
Creates a reusable workflow to for our different repositories.