### PR TITLE
chore: enable renovate pre-commit manager by default

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":semanticCommits",
     ":semanticCommitScopeDisabled",
-    ":semanticCommitTypeAll(deps)"
+    ":semanticCommitTypeAll(deps)",
+    ":enablePreCommit"
   ]
 }


### PR DESCRIPTION
Cherry picking the renovate default preset changes from #7 