### PR TITLE
chore: remove renovate-config-validator hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,6 @@ repos:
       - id: prettier
         files: \.(md|ya?ml|json)$
 
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.8.1
-    hooks:
-      - id: renovate-config-validator
-
   - repo: local
     hooks:
       - id: shfmt


### PR DESCRIPTION
The hook generate too much noise for not much value added.

See #14 