### PR TITLE
feat: add renovate regex for gha workflows version variable

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -9,7 +9,7 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["^\\.github\\/(?:workflows|actions)\\/[^/]+\\.ya?ml$"],
+      "fileMatch": ["^\\.github\\/(?:workflows|actions)\\/.+\\.ya?ml$"],
       "matchStrings": [
         "^\\s+(?:[a-zA-Z-_]+)?(?:version|VERSION): (?<currentValue>.+?) # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?$"
       ]

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -6,5 +6,13 @@
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)",
     ":enablePreCommit"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.github\\/(?:workflows|actions)\\/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "\\s+(?:[a-zA-Z-_]+)?(?:version|VERSION): (?<currentValue>.+?) # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\n"
+      ]
+    }
   ]
 }

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -11,7 +11,7 @@
     {
       "fileMatch": ["^\\.github\\/(?:workflows|actions)\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
-        "\\s+(?:[a-zA-Z-_]+)?(?:version|VERSION): (?<currentValue>.+?) # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\n"
+        "^\\s+(?:[a-zA-Z-_]+)?(?:version|VERSION): (?<currentValue>.+?) # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?$"
       ]
     }
   ]


### PR DESCRIPTION
This should be able to match the following strings:
```yaml
jobs:
  lint:
    steps:
      - uses: golangci/golangci-lint-action@v3
        with:
          version: v1.55.1 # renovate: datasource=github-releases depName=golangci/golangci-lint
```