### PR TITLE
chore: add default issue templates for the github org

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,56 @@
+name: Bug Report
+description: Report a bug
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filing a bug. Please complete the form below so we can triage,
+        reproduce, and fix your issue.
+
+        Make sure that it does not contain sensitive information.
+
+  - id: tldr
+    type: textarea
+    attributes:
+      label: TL;DR
+      description: Describe the bug in 1-2 sentences.
+    validations:
+      required: true
+
+  - id: expected-behavior
+    type: textarea
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - id: observed-behavior
+    type: textarea
+    attributes:
+      label: Observed behavior
+      description: What happened instead?
+    validations:
+      required: true
+
+  - id: minimal-working-example
+    type: textarea
+    attributes:
+      label: Minimal working example
+      description: |
+        Please provide a minimal working example for us to reproduce and fix your issue.
+
+  - id: log-output
+    type: textarea
+    attributes:
+      label: Log output
+      description: Please paste all log output here.
+      render: plain text
+
+  - id: additional-information
+    type: textarea
+    attributes:
+      label: Additional information
+      description: |
+        Is there anything else you think we should know (e.g. versions, links, ...)?

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,1 +1,0 @@
-blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Request a feature
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for requesting a feature. Please complete the form below so we can
+        triage and prioritize your feature.
+
+  - id: tldr
+    type: textarea
+    attributes:
+      label: TL;DR
+      description: Describe the feature in 1-2 sentences.
+    validations:
+      required: true
+
+  - id: expected-behavior
+    type: textarea
+    attributes:
+      label: Expected behavior
+      description: |
+        What are you expecting to happen? Provide as many details as possible and
+        include samples when relevant.
+    validations:
+      required: true


### PR DESCRIPTION
Add forms for bug report or feature request, for repositories that do not implement their own.