### PR TITLE
feat: auto merge pre-commit non major updates

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -8,6 +8,13 @@
     ":enablePreCommit",
     ":enableVulnerabilityAlerts"
   ],
+  "packageRules": [
+    {
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Now that renovate is allowed to auto merge PRs, we can auto merge some pre-commit updates. Pre-commit should always run in our CI workflows, so a failed version bump should prevent merging a broken update.

Minor or patch auto fixes are allowed (pre-commit will commit back to the renovate branch with the fixes).