### PR TITLE
feat: auto merge golangci-lint and patch versions

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -10,8 +10,20 @@
   ],
   "packageRules": [
     {
+      "description": ["automerge pre-commit hooks minor and patch version"],
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": ["automerge golangci-lint minor and patch version"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepNames": ["golangci/golangci-lint"],
+      "automerge": true
+    },
+    {
+      "description": ["automerge patch version"],
+      "updateTypes": ["patch"],
       "automerge": true
     }
   ],


### PR DESCRIPTION
Enable automerge for:
- automerge golangci-lint minor and patch version
- automerge patch version