### PR TITLE
feat: extract version with pattern using renovate regex manager

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -32,7 +32,7 @@
       "customType": "regex",
       "fileMatch": ["^\\.github\\/(?:workflows|actions)\\/.+\\.ya?ml$"],
       "matchStrings": [
-        "(?:version|VERSION): (?<currentValue>.+) # renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>.+)(?: lookupName=(?<lookupName>.+))?(?: versioning=(?<versioning>[a-z-]+))?"
+        "(?:version|VERSION): (?<currentValue>.+) # renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>.+)(?: lookupName=(?<lookupName>.+))?(?: versioning=(?<versioning>[a-z-]+))?(?: extractVersion=(?<extractVersion>.+))?"
       ]
     }
   ]


### PR DESCRIPTION
This will allow extracting the version for a GitHub release tag, before swapping the value, for example when the `v` prefix is undesired:

```yml
      - uses: hashicorp/setup-packer@v3.1.0
        with:
          version: "1.10.0" # renovate: datasource=github-releases depName=hashicorp/packer extractVersion=v(?<version>.+)
```