### PR TITLE
fix: regex manager variables

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -30,9 +30,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github\\/(?:workflows|actions)\\/.+\\.ya?ml$"],
+      "fileMatch": [".+\\.ya?ml$"],
       "matchStrings": [
-        "(?:version|VERSION): (?<currentValue>.+) # renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>.+)(?: lookupName=(?<lookupName>.+))?(?: versioning=(?<versioning>[a-z-]+))?(?: extractVersion=(?<extractVersion>.+))?"
+        ": (?<currentValue>.+) # renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)(?: lookupName=(?<lookupName>[^\\s]+))?(?: versioning=(?<versioning>[a-z-]+))?(?: extractVersion=(?<extractVersion>[^\\s]+))?"
       ]
     }
   ]


### PR DESCRIPTION
- Fix the different variables extraction.
- Relax where the regex manager can be used (remove variable name, remove GitHub action filenames).