### PR TITLE
fix: use default renovate semantic commit config

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -3,8 +3,6 @@
   "extends": [
     "config:recommended",
     ":semanticCommits",
-    ":semanticCommitScopeDisabled",
-    ":semanticCommitTypeAll(deps)",
     ":enablePreCommit",
     ":enableVulnerabilityAlerts"
   ],


### PR DESCRIPTION
Let renovate decide how to scope our dependencies updates.

https://docs.renovatebot.com/semantic-commits/