### PR TITLE
feat: manage renovate golang updates

### DIFF
--- a/renovate/golang.json
+++ b/renovate/golang.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [":semanticCommitScopeDisabled", ":semanticCommitTypeAll(deps)"]
+  "extends": [":semanticCommitScopeDisabled", ":semanticCommitTypeAll(deps)"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["go", "golang"],
+      "matchDepTypes": ["toolchain", "image", "stage"],
+      "allowedVersions": "<1.23"
+    }
+  ]
 }


### PR DESCRIPTION
We can bump the version of golang in here, and it should propagate to all our repository.

This prevents having a bunch of open renovate PR lying around.