### PR TITLE
feat(renovate): Update go import paths on major updates

### DIFF
--- a/renovate/golang.json
+++ b/renovate/golang.json
@@ -7,5 +7,6 @@
       "matchDepTypes": ["toolchain", "image", "stage"],
       "allowedVersions": "<1.24"
     }
-  ]
+  ],
+  "postUpdateOptions": ["gomodUpdateImportPaths"]
 }


### PR DESCRIPTION
If we don't adjust the import paths on a major update, Renovate will only update our go.mod file, but keep the old major version. As a result we introduced a change with no effect. By updating the import paths the CI will fail and show breaking changes, that need to be fixed before updating.