### PR TITLE
feat: we are not ready for golangci-lint v2 yet

### DIFF
--- a/renovate/golang.json
+++ b/renovate/golang.json
@@ -6,6 +6,10 @@
       "matchPackageNames": ["go", "golang"],
       "matchDepTypes": ["toolchain", "image", "stage"],
       "allowedVersions": "<1.25"
+    },
+    {
+      "matchPackageNames": ["golangci/golangci-lint"],
+      "allowedVersions": "<2.0.0"
     }
   ],
   "postUpdateOptions": ["gomodUpdateImportPaths"]


### PR DESCRIPTION
Pin the golangci-lint version to <2, as they dropped presets which we use extensively. We hope to see a new linters grouping or a remote configuration feature show up.