### PR TITLE
feat: github action pinning and min release age

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -18,7 +18,10 @@
     {
       "description": ["do not delay updates for our own GitHub Actions"],
       "matchManagers": ["github-actions"],
-      "matchSourceUrls": ["https://github.com/hetznercloud/**"],
+      "matchSourceUrls": [
+        "https://github.com/hetznercloud/**",
+        "https://github.com/hetzner/**"
+      ],
       "minimumReleaseAge": "0 seconds",
       "minimumReleaseAgeBehavior": "timestamp-optional",
       "schedule": ["at any time"]

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -7,12 +7,13 @@
     ":enableVulnerabilityAlerts",
     "helpers:pinGitHubActionDigests"
   ],
+  "minimumReleaseAge": "5 days",
+  "minimumReleaseAgeBehavior": "timestamp-optional",
   "packageRules": [
     {
-      "description": ["delay updates and only update weekly"],
-      "minimumReleaseAge": "5 days",
-      "minimumReleaseAgeBehavior": "timestamp-optional",
-      "schedule": ["on monday"]
+      "description": ["update actions every monday"],
+      "matchManagers": ["github-actions"],
+      "schedule": ["on sunday"]
     },
     {
       "description": ["do not delay updates for our own packages"],
@@ -21,8 +22,7 @@
         "https://github.com/hetzner/**"
       ],
       "minimumReleaseAge": "0 seconds",
-      "minimumReleaseAgeBehavior": "timestamp-optional",
-      "schedule": ["at any time"]
+      "minimumReleaseAgeBehavior": "timestamp-optional"
     },
     {
       "description": ["automerge pre-commit hooks minor and patch version"],

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -11,7 +11,7 @@
   "minimumReleaseAgeBehavior": "timestamp-optional",
   "packageRules": [
     {
-      "description": ["update actions every monday"],
+      "description": ["update actions weekly"],
       "matchManagers": ["github-actions"],
       "schedule": ["on sunday"]
     },

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,9 +4,25 @@
     "config:recommended",
     ":semanticCommits",
     ":enablePreCommit",
-    ":enableVulnerabilityAlerts"
+    ":enableVulnerabilityAlerts",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
+    {
+      "description": ["delay GitHub Actions updates and only update weekly"],
+      "matchManagers": ["github-actions"],
+      "minimumReleaseAge": "5 days",
+      "minimumReleaseAgeBehavior": "timestamp-optional",
+      "schedule": ["on monday"]
+    },
+    {
+      "description": ["do not delay updates for our own GitHub Actions"],
+      "matchManagers": ["github-actions"],
+      "matchSourceUrls": ["https://github.com/hetznercloud/**"],
+      "minimumReleaseAge": "0 seconds",
+      "minimumReleaseAgeBehavior": "timestamp-optional",
+      "schedule": ["at any time"]
+    },
     {
       "description": ["automerge pre-commit hooks minor and patch version"],
       "matchManagers": ["pre-commit"],

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -9,15 +9,13 @@
   ],
   "packageRules": [
     {
-      "description": ["delay GitHub Actions updates and only update weekly"],
-      "matchManagers": ["github-actions"],
+      "description": ["delay updates and only update weekly"],
       "minimumReleaseAge": "5 days",
       "minimumReleaseAgeBehavior": "timestamp-optional",
       "schedule": ["on monday"]
     },
     {
-      "description": ["do not delay updates for our own GitHub Actions"],
-      "matchManagers": ["github-actions"],
+      "description": ["do not delay updates for our own packages"],
       "matchSourceUrls": [
         "https://github.com/hetznercloud/**",
         "https://github.com/hetzner/**"
@@ -42,11 +40,6 @@
       "description": ["automerge patch version"],
       "updateTypes": ["patch"],
       "automerge": true
-    },
-    {
-      "description": ["cert-manager releases are spread over a long time"],
-      "matchDepNames": ["cert-manager", "github.com/cert-manager/cert-manager"],
-      "minimumReleaseAge": "2 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Pin GitHub action and update them only once a week. Only consider releases with a minimum age of five days.